### PR TITLE
Fix root namespace to RealityToolkit

### DIFF
--- a/Editor/Serialization/Importers/GlbAssetImporter.cs
+++ b/Editor/Serialization/Importers/GlbAssetImporter.cs
@@ -4,7 +4,7 @@ using UnityEditor.AssetImporters;
 using UnityEditor.Experimental.AssetImporters;
 #endif
 
-namespace XRTK.Utilities.Gltf.Serialization.Importers
+namespace RealityToolkit.Utilities.Gltf.Serialization.Importers
 {
     [ScriptedImporter(1, "glb")]
     public class GlbAssetImporter : ScriptedImporter

--- a/Editor/Serialization/Importers/GltfAssetImporter.cs
+++ b/Editor/Serialization/Importers/GltfAssetImporter.cs
@@ -4,7 +4,7 @@ using UnityEditor.AssetImporters;
 using UnityEditor.Experimental.AssetImporters;
 #endif
 
-namespace XRTK.Utilities.Gltf.Serialization.Importers
+namespace RealityToolkit.Utilities.Gltf.Serialization.Importers
 {
     [ScriptedImporter(1, "gltf")]
     public class GltfAssetImporter : ScriptedImporter

--- a/Editor/Serialization/Importers/GltfEditorImporter.cs
+++ b/Editor/Serialization/Importers/GltfEditorImporter.cs
@@ -8,7 +8,7 @@ using System.IO;
 using UnityEditor;
 using UnityEngine;
 
-namespace XRTK.Utilities.Gltf.Serialization.Importers
+namespace RealityToolkit.Utilities.Gltf.Serialization.Importers
 {
     public static class GltfEditorImporter
     {

--- a/Editor/glTFPathFinder.cs
+++ b/Editor/glTFPathFinder.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using RealityToolkit.Editor.Utilities;
 using UnityEngine;
-using XRTK.Editor.Utilities;
 
-namespace XRTK.glTF.Editor
+namespace RealityToolkit.glTF.Editor
 {
     /// <summary>
     /// Dummy scriptable object used to find the relative path of the com.xrtk.glTF.

--- a/Runtime/Schema/Extensions/GltfExtension.cs
+++ b/Runtime/Schema/Extensions/GltfExtension.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema.Extensions
+namespace RealityToolkit.Utilities.Gltf.Schema.Extensions
 {
     public class GltfExtension
     {

--- a/Runtime/Schema/Extensions/KHR_Materials_PbrSpecularGlossiness.cs
+++ b/Runtime/Schema/Extensions/KHR_Materials_PbrSpecularGlossiness.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace XRTK.Utilities.Gltf.Schema.Extensions
+namespace RealityToolkit.Utilities.Gltf.Schema.Extensions
 {
     [Serializable]
     public class KHR_Materials_PbrSpecularGlossiness : GltfExtension

--- a/Runtime/Schema/GltfAccessor.cs
+++ b/Runtime/Schema/GltfAccessor.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/accessor.schema.json

--- a/Runtime/Schema/GltfAccessorAttributeType.cs
+++ b/Runtime/Schema/GltfAccessorAttributeType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Specifies if the attribute is a scalar, vector, or matrix.

--- a/Runtime/Schema/GltfAccessorSparse.cs
+++ b/Runtime/Schema/GltfAccessorSparse.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Sparse storage of attributes that deviate from their initialization value.

--- a/Runtime/Schema/GltfAccessorSparseIndices.cs
+++ b/Runtime/Schema/GltfAccessorSparseIndices.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Indices of those attributes that deviate from their initialization value.

--- a/Runtime/Schema/GltfAccessorSparseValues.cs
+++ b/Runtime/Schema/GltfAccessorSparseValues.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/accessor.sparse.values.schema.json

--- a/Runtime/Schema/GltfAlphaMode.cs
+++ b/Runtime/Schema/GltfAlphaMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// The alpha rendering mode of the material.

--- a/Runtime/Schema/GltfAnimation.cs
+++ b/Runtime/Schema/GltfAnimation.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// A keyframe animation.

--- a/Runtime/Schema/GltfAnimationChannel.cs
+++ b/Runtime/Schema/GltfAnimationChannel.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Targets an animation's sampler at a node's property.

--- a/Runtime/Schema/GltfAnimationChannelPath.cs
+++ b/Runtime/Schema/GltfAnimationChannelPath.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// The name of the node's TRS property to modify, or the weights of the Morph Target it instantiates.

--- a/Runtime/Schema/GltfAnimationChannelTarget.cs
+++ b/Runtime/Schema/GltfAnimationChannelTarget.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// The index of the node and TRS property that an animation channel targets.

--- a/Runtime/Schema/GltfAnimationSampler.cs
+++ b/Runtime/Schema/GltfAnimationSampler.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Combines input and output accessors with an interpolation algorithm to define a keyframe graph (but not its target).

--- a/Runtime/Schema/GltfAssetInfo.cs
+++ b/Runtime/Schema/GltfAssetInfo.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Metadata about the glTF asset.

--- a/Runtime/Schema/GltfBuffer.cs
+++ b/Runtime/Schema/GltfBuffer.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// A buffer points to binary geometry, animation, or skins.

--- a/Runtime/Schema/GltfBufferView.cs
+++ b/Runtime/Schema/GltfBufferView.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// A view into a buffer generally representing a subset of the buffer.

--- a/Runtime/Schema/GltfBufferViewTarget.cs
+++ b/Runtime/Schema/GltfBufferViewTarget.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// The target that the GPU buffer should be bound to.

--- a/Runtime/Schema/GltfCamera.cs
+++ b/Runtime/Schema/GltfCamera.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// A camera's projection.  A node can reference a camera to apply a transform

--- a/Runtime/Schema/GltfCameraOrthographic.cs
+++ b/Runtime/Schema/GltfCameraOrthographic.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// An orthographic camera containing properties to create an orthographic

--- a/Runtime/Schema/GltfCameraPerspective.cs
+++ b/Runtime/Schema/GltfCameraPerspective.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// A perspective camera containing properties to create a perspective projection

--- a/Runtime/Schema/GltfCameraType.cs
+++ b/Runtime/Schema/GltfCameraType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Specifies if the camera uses a perspective or orthographic projection.

--- a/Runtime/Schema/GltfChildOfRootProperty.cs
+++ b/Runtime/Schema/GltfChildOfRootProperty.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/glTFChildOfRootProperty.schema.json

--- a/Runtime/Schema/GltfComponentType.cs
+++ b/Runtime/Schema/GltfComponentType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/accessor.schema.json:componentType <para/>

--- a/Runtime/Schema/GltfDrawMode.cs
+++ b/Runtime/Schema/GltfDrawMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// The type of primitives to render.

--- a/Runtime/Schema/GltfImage.cs
+++ b/Runtime/Schema/GltfImage.cs
@@ -4,7 +4,7 @@
 using System;
 using UnityEngine;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Image data used to create a texture. Image can be referenced by URI or

--- a/Runtime/Schema/GltfInterpolationType.cs
+++ b/Runtime/Schema/GltfInterpolationType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Interpolation algorithm.

--- a/Runtime/Schema/GltfMagnificationFilterMode.cs
+++ b/Runtime/Schema/GltfMagnificationFilterMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Magnification filter mode.

--- a/Runtime/Schema/GltfMaterial.cs
+++ b/Runtime/Schema/GltfMaterial.cs
@@ -4,7 +4,7 @@
 using System;
 using UnityEngine;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// The material appearance of a primitive.

--- a/Runtime/Schema/GltfMaterialCommonConstant.cs
+++ b/Runtime/Schema/GltfMaterialCommonConstant.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     [Serializable]
     public class GltfMaterialCommonConstant : GltfProperty

--- a/Runtime/Schema/GltfMesh.cs
+++ b/Runtime/Schema/GltfMesh.cs
@@ -4,7 +4,7 @@
 using System;
 using UnityEngine;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// A set of primitives to be rendered. A node can contain one or more meshes.

--- a/Runtime/Schema/GltfMeshPrimitive.cs
+++ b/Runtime/Schema/GltfMeshPrimitive.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Geometry to be rendered with the given material.

--- a/Runtime/Schema/GltfMeshPrimitiveAttributes.cs
+++ b/Runtime/Schema/GltfMeshPrimitiveAttributes.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Common mesh primitive attributes.

--- a/Runtime/Schema/GltfMinFilterMode.cs
+++ b/Runtime/Schema/GltfMinFilterMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Minification filter mode.

--- a/Runtime/Schema/GltfNode.cs
+++ b/Runtime/Schema/GltfNode.cs
@@ -4,7 +4,7 @@
 using System;
 using UnityEngine;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// A node in the node hierarchy.

--- a/Runtime/Schema/GltfNormalTextureInfo.cs
+++ b/Runtime/Schema/GltfNormalTextureInfo.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/material.normalTextureInfo.schema.json

--- a/Runtime/Schema/GltfObject.cs
+++ b/Runtime/Schema/GltfObject.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using RealityToolkit.Utilities.Gltf.Schema.Extensions;
 using UnityEngine;
-using XRTK.Utilities.Gltf.Schema.Extensions;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     [Serializable]
     public class GltfObject : GltfProperty

--- a/Runtime/Schema/GltfOcclusionTextureInfo.cs
+++ b/Runtime/Schema/GltfOcclusionTextureInfo.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/material.occlusionTextureInfo.schema.json

--- a/Runtime/Schema/GltfPbrMetallicRoughness.cs
+++ b/Runtime/Schema/GltfPbrMetallicRoughness.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// A set of parameter values that are used to define the metallic-roughness material model from Physically-Based Rendering (PBR) methodology.

--- a/Runtime/Schema/GltfProperty.cs
+++ b/Runtime/Schema/GltfProperty.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     public class GltfProperty
     {

--- a/Runtime/Schema/GltfSampler.cs
+++ b/Runtime/Schema/GltfSampler.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Texture sampler properties for filtering and wrapping modes.

--- a/Runtime/Schema/GltfScene.cs
+++ b/Runtime/Schema/GltfScene.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// The indices of each root node.

--- a/Runtime/Schema/GltfSkin.cs
+++ b/Runtime/Schema/GltfSkin.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Joints and matrices defining a skin.

--- a/Runtime/Schema/GltfTexture.cs
+++ b/Runtime/Schema/GltfTexture.cs
@@ -4,7 +4,7 @@
 using System;
 using UnityEngine;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// A texture and its sampler.

--- a/Runtime/Schema/GltfTextureInfo.cs
+++ b/Runtime/Schema/GltfTextureInfo.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/textureInfo.schema.json

--- a/Runtime/Schema/GltfWrapMode.cs
+++ b/Runtime/Schema/GltfWrapMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Schema
+namespace RealityToolkit.Utilities.Gltf.Schema
 {
     /// <summary>
     /// Texture wrap mode.

--- a/Runtime/Serialization/ColliderType.cs
+++ b/Runtime/Serialization/ColliderType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Serialization
+namespace RealityToolkit.Utilities.Gltf.Serialization
 {
     public enum ColliderType
     {

--- a/Runtime/Serialization/ConstructGltf.cs
+++ b/Runtime/Serialization/ConstructGltf.cs
@@ -5,14 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using RealityToolkit.Utilities.Async;
+using RealityToolkit.Utilities.Gltf.Schema;
+using RealityToolkit.Utilities.WebRequestRest;
 using UnityEngine;
 using UnityEngine.Rendering;
-using XRTK.Extensions;
-using XRTK.Utilities.Async;
-using XRTK.Utilities.Gltf.Schema;
-using XRTK.Utilities.WebRequestRest;
+using RealityToolkit.Extensions;
 
-namespace XRTK.Utilities.Gltf.Serialization
+namespace RealityToolkit.Utilities.Gltf.Serialization
 {
     public static class ConstructGltf
     {

--- a/Runtime/Serialization/ExportGltf.cs
+++ b/Runtime/Serialization/ExportGltf.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Serialization
+namespace RealityToolkit.Utilities.Gltf.Serialization
 {
     public class ExportGltf
     {

--- a/Runtime/Serialization/GltfAsset.cs
+++ b/Runtime/Serialization/GltfAsset.cs
@@ -1,7 +1,7 @@
-﻿using UnityEngine;
-using XRTK.Utilities.Gltf.Schema;
+﻿using RealityToolkit.Utilities.Gltf.Schema;
+using UnityEngine;
 
-namespace XRTK.Utilities.Gltf
+namespace RealityToolkit.Utilities.Gltf
 {
     public class GltfAsset : ScriptableObject
     {

--- a/Runtime/Serialization/GltfChunkType.cs
+++ b/Runtime/Serialization/GltfChunkType.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace XRTK.Utilities.Gltf.Serialization
+namespace RealityToolkit.Utilities.Gltf.Serialization
 {
     public enum GltfChunkType : uint
     {

--- a/Runtime/Serialization/GltfConversions.cs
+++ b/Runtime/Serialization/GltfConversions.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using RealityToolkit.Utilities.Gltf.Schema;
 using UnityEngine;
-using XRTK.Utilities.Gltf.Schema;
 
-namespace XRTK.Utilities.Gltf.Serialization
+namespace RealityToolkit.Utilities.Gltf.Serialization
 {
     internal static class GltfConversions
     {

--- a/Runtime/Serialization/GltfUtility.cs
+++ b/Runtime/Serialization/GltfUtility.cs
@@ -9,14 +9,14 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using RealityToolkit.Utilities.Async;
+using RealityToolkit.Utilities.Async.Internal;
+using RealityToolkit.Utilities.Gltf.Schema;
+using RealityToolkit.Utilities.WebRequestRest;
 using UnityEngine;
-using XRTK.Extensions;
-using XRTK.Utilities.Async;
-using XRTK.Utilities.Async.Internal;
-using XRTK.Utilities.Gltf.Schema;
-using XRTK.Utilities.WebRequestRest;
+using RealityToolkit.Extensions;
 
-namespace XRTK.Utilities.Gltf.Serialization
+namespace RealityToolkit.Utilities.Gltf.Serialization
 {
     public static class GltfUtility
     {


### PR DESCRIPTION
# Reality Collective - Reality Toolkit Pull Request

## Overview

Replaces the old `XRTK` root namespace with `RealityToolkit`.